### PR TITLE
Use simple quotes to prevent UnicodeDecodeError on install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Docflow: Python Document Workflows
 ==================================
 
 Docflow is an implementation of document workflows in Python. A workflow
-defines `states` and `transitions`. A state is an “end point” associated with
+defines `states` and `transitions`. A state is an "end point" associated with
 a document. A transition is a path from one state to another state
 (unidirectional). Docflow was inspired by `repoze.workflow`_ but aspires
 to be a framework-independent implementation.


### PR DESCRIPTION
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\roche\AppData\Local\Temp\pip-build-xf0pde82\docflow\setup.py", line 7, in <module>
        README = open(os.path.join(here, 'README.rst')).read()
      File "c:\users\roche\projects\tarmii\lib\encodings\cp1252.py", line 23, in decode
        return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 208: character maps to <undefined>